### PR TITLE
Kampyle Feedback Widget

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -5,3 +5,22 @@ import { sampleRUM } from './lib-franklin.js';
 sampleRUM('cwv');
 
 // add more delayed functionality here
+
+const loadScript = (url, attrs) => {
+  const head = document.querySelector('head');
+  const script = document.createElement('script');
+  script.src = url;
+  if (attrs) {
+    // eslint-disable-next-line no-restricted-syntax, guard-for-in
+    for (const attr in attrs) {
+      script.setAttribute(attr, attrs[attr]);
+    }
+  }
+  head.append(script);
+  return script;
+};
+
+loadScript('https://resources.digital-cloud-west.medallia.com/wdcwest/378975/onsite/embed.js', {
+  type: 'text/javascript',
+  async: true,
+});


### PR DESCRIPTION
Configuration of the Allow-List on the Medallia service is required.
https://docs.medallia.com/en/medallia-digital/medallia-digital-web/administration-guide/allow-list-guidance

Fix #14 

Test URLs:
- Before: https://main--walgreens--hlxsites.hlx.live/walgreens-online-deals
- After: https://kampyle-widget--walgreens--hlxsites.hlx.live/walgreens-online-deals
