### PR TITLE
feat: Allow API calls for cards

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
     'import/extensions': ['error', {
       js: 'always',
     }],
+    'function-paren-newline': 'off',
   },
 };

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -67,7 +67,7 @@ async function decorateAPICards(block) {
               img({
                 src: new URL(offer.imageUrl, 'https://www.walgreens.com').toString(),
                 loading: 'lazy',
-                alt: offer.title,
+                alt: `Offer Image: ${offer.title}`,
               }),
             ),
             div({ class: 'card-body' },


### PR DESCRIPTION
Test URLs:
Card block only:
- Before: https://main--walgreens--hlxsites.hlx.live/drafts/tuicu/cards-with-api
- After: https://api-cards--walgreens--hlxsites.hlx.live/drafts/tuicu/cards-with-api

Full page copy (has both cards with curated content and cards from API)
- Before: https://main--walgreens--hlxsites.hlx.live/drafts/tuicu/beautydeals
- After: https://api-cards--walgreens--hlxsites.hlx.live/drafts/tuicu/beautydeals