### PR TITLE
fix: card sizes after importing external walgreens css

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -19,6 +19,7 @@
   margin: 0;
   padding: 0;
   vertical-align: baseline;
+  height: unset !important;      /* overwrite external CSS */
 }
 
 .card > a {


### PR DESCRIPTION
The PRs for introducing the header #36 and footer #34 are importing external CSS from walgreens which is interfering with the block CSS.

Test URLs:
- Before: https://main--walgreens--hlxsites.hlx.live/beautydeals
- After: https://fix-cards--walgreens--hlxsites.hlx.live/beautydeals
