### PR TITLE
Add queryParam to block header/footer from loading

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -198,7 +198,7 @@ async function loadLazy(doc) {
     loadHeader(doc.querySelector('header'));
     loadFooter(doc.querySelector('footer'));
   }
-  
+
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -192,9 +192,13 @@ async function loadLazy(doc) {
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'));
-  loadFooter(doc.querySelector('footer'));
-
+  // TODO: remove this check before go-live
+  const noHeader = new URLSearchParams(window.location.search).has('test');
+  if (!noHeader) {
+    loadHeader(doc.querySelector('header'));
+    loadFooter(doc.querySelector('footer'));
+  }
+  
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
 


### PR DESCRIPTION
Loading the Walgreens headerui and footerui severely impacts all of our PSI when submitting a PR. In order to bypass this, I've added a query param check to skip loading them.

Add "?test" to the end of the URL to skip loading the header and footer.

Fix #50 

Test URLs:
- Before: https://main--walgreens--hlxsites.hlx.page/beautydeals
- After: https://include-blocker--walgreens--hlxsites.hlx.page/beautydeals?test
