### PR TITLE
25 - Breadcrumb

### DIFF
--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -1,3 +1,11 @@
+.breadcrumb.desktop {
+  display: block;
+}
+
+.breadcrumb.mobile {
+  display: none;
+}
+
 .breadcrumb ul {
   list-style: none;
   display: flex;
@@ -25,6 +33,10 @@
   min-height: unset;
 }
 
+.breadcrumb li:last-child .icon {
+  display: none;
+}
+
 .breadcrumb li a svg {
   fill: #707575;
   bottom: -2px;
@@ -45,7 +57,26 @@
 }
 
 @media (max-width: 700px) {
-  .breadcrumb {
+  .breadcrumb.desktop {
     display: none;
+  }
+
+  .breadcrumb.mobile {
+    display: block;
+    margin-bottom: 60px;
+  }
+
+  .breadcrumb ul {
+    flex-direction: column;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .breadcrumb.mobile li {
+    margin-top: 10px;
+  }
+
+  .breadcrumb.mobile li a {
+    font-size: 1rem;
   }
 }

--- a/blocks/breadcrumb/breadcrumb.css
+++ b/blocks/breadcrumb/breadcrumb.css
@@ -16,8 +16,13 @@
 }
 
 .breadcrumb li .icon {
+  position: static;
+  overflow: visible;
+  display: inline-block;
   height: unset;
   width: unset;
+  min-width: unset;
+  min-height: unset;
 }
 
 .breadcrumb li a svg {
@@ -27,6 +32,8 @@
   margin: 0;
   padding: 0;
   position: absolute;
+  left: unset;
+  top: unset;
   right: -10px;
   width: 30px;
 }

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -49,7 +49,6 @@ export default async function decorate(block) {
         && mutation.attributeName === 'data-section-status'
         && previousSection.attributes.getNamedItem('data-section-status').value === 'loaded') {
         observer.disconnect();
-        console.log('here');
         mobileBlock.style.display = null;
       }
     });

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -10,11 +10,12 @@ export default async function decorate(block) {
   const mobileSection = (
     div({ class: 'section breadcrumb-container', 'data-section-status': 'loading' },
       div({ class: 'breadcrumb-wrapper' },
-        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': 'loading' }),
+        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': 'loaded' }),
       ),
     )
   );
   const mobileBlock = mobileSection.querySelector('.block');
+  mobileBlock.style.display = 'none'; // hide in the beginning to avoid CLS
   mobileBlock.append(desktopBlock.children[0].cloneNode(true));
 
   const main = block.closest('main');
@@ -39,4 +40,20 @@ export default async function decorate(block) {
       strong(linkText),
     );
   });
+
+  // only show the mobile breadcrumb, once the previous section is fully loaded
+  const previousSection = mobileSection.previousElementSibling;
+  const observer = new MutationObserver((mutationList) => {
+    mutationList.forEach((mutation) => {
+      if (mutation.type === 'attributes'
+        && mutation.attributeName === 'data-section-status'
+        && previousSection.attributes.getNamedItem('data-section-status').value === 'loaded') {
+        observer.disconnect();
+        console.log('here');
+        mobileBlock.style.display = null;
+      }
+    });
+  });
+
+  observer.observe(previousSection, { attributes: true });
 }

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -10,12 +10,16 @@ export default async function decorate(block) {
   const mobileSection = (
     div({ class: 'section breadcrumb-container', 'data-section-status': 'loading' },
       div({ class: 'breadcrumb-wrapper' },
-        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': 'loaded' }),
+        div({
+          class: 'breadcrumb block mobile',
+          style: 'display: none;', // hide in the beginning to avoid CLS
+          'data-block-name': 'breadcrumb',
+          'data-block-status': 'loaded',
+        }),
       ),
     )
   );
   const mobileBlock = mobileSection.querySelector('.block');
-  mobileBlock.style.display = 'none'; // hide in the beginning to avoid CLS
   mobileBlock.append(desktopBlock.children[0].cloneNode(true));
 
   const main = block.closest('main');

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -7,12 +7,13 @@ export default async function decorate(block) {
 
   // duplicate breadcrumb information in a new section + block for mobile
   // at the and of the page
-  const mobileSection = 
+  const mobileSection = (
     div({ class: 'section breadcrumb-container', 'data-section-status': 'loading' },
       div({ class: 'breadcrumb-wrapper' },
-        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': "loaded" }),
-      ),  
-    );
+        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': 'loading' }),
+      ),
+    )
+  );
   const mobileBlock = mobileSection.querySelector('.block');
   mobileBlock.append(desktopBlock.children[0].cloneNode(true));
 
@@ -20,9 +21,11 @@ export default async function decorate(block) {
   main.append(mobileSection);
 
   // decorate desktop block
-  desktopBlock.querySelectorAll('li').forEach((item, idx, arr) => {
+  desktopBlock.querySelectorAll('li').forEach((item) => {
     const link = item.querySelector('a');
-    link && link.appendChild(span({ class: 'icon icon-arrow-right' }));
+    if (!link) return;
+
+    link.appendChild(span({ class: 'icon icon-arrow-right' }));
   });
   await decorateIcons(desktopBlock);
 

--- a/blocks/breadcrumb/breadcrumb.js
+++ b/blocks/breadcrumb/breadcrumb.js
@@ -1,17 +1,39 @@
+import { div, span, strong } from '../../scripts/dom-helpers.js';
 import { decorateIcons } from '../../scripts/lib-franklin.js';
 
 export default async function decorate(block) {
-  block.querySelectorAll('li a').forEach((link, idx, arr) => {
-    if (!idx < arr.length - 1) {
-      return;
-    }
+  const desktopBlock = block;
+  desktopBlock.classList.add('desktop');
 
-    const icon = document.createElement('span');
-    icon.classList.add('icon');
-    icon.classList.add('icon-arrow-right');
+  // duplicate breadcrumb information in a new section + block for mobile
+  // at the and of the page
+  const mobileSection = 
+    div({ class: 'section breadcrumb-container', 'data-section-status': 'loading' },
+      div({ class: 'breadcrumb-wrapper' },
+        div({ class: 'breadcrumb block mobile', 'data-block-name': 'breadcrumb', 'data-block-status': "loaded" }),
+      ),  
+    );
+  const mobileBlock = mobileSection.querySelector('.block');
+  mobileBlock.append(desktopBlock.children[0].cloneNode(true));
 
-    link.appendChild(icon);
+  const main = block.closest('main');
+  main.append(mobileSection);
+
+  // decorate desktop block
+  desktopBlock.querySelectorAll('li').forEach((item, idx, arr) => {
+    const link = item.querySelector('a');
+    link && link.appendChild(span({ class: 'icon icon-arrow-right' }));
   });
+  await decorateIcons(desktopBlock);
 
-  await decorateIcons(block);
+  // decorate mobile block
+  mobileBlock.querySelectorAll('li a').forEach((link) => {
+    const linkText = link.textContent;
+    link.textContent = '';
+
+    link.append(
+      document.createTextNode('‹ '),
+      strong(linkText),
+    );
+  });
 }


### PR DESCRIPTION
Fix: Breadcrumb styling after loading header + footer
Add Mobile Breadcrumb. It is not hidden on mobile, it appears at the bottom of the page instead.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #25

Test URLs:
- Before: https://main--walgreens--hlxsites.hlx.live/beautydeals
- After: https://fix-breadcrumb--walgreens--hlxsites.hlx.live/beautydeals?test
