### PR TITLE
fix - namespace cards to avoid clash with Walgreens external CSS

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -12,7 +12,7 @@
   justify-content: flex-start;
 }
 
-.card {
+.franklin-card {
   width: calc(25% - 15px); /* default 4 columns */
   backface-visibility: hidden;
   font: inherit;
@@ -22,18 +22,18 @@
   height: unset !important;      /* overwrite external CSS */
 }
 
-.card > a {
+.franklin-card > a {
   display: block;
   width: 100%;
 }
 
-.card.with-border {
+.franklin-card.with-border {
   box-shadow: 0 1px 6px 1px rgba(64 64 64 / 15%);
   border-radius: 8px;
   margin: 10px 0;
 }
 
-.card .card-image {
+.franklin-card .card-image {
   line-height: 0;
   margin-bottom: 20px;
   height: 180px;
@@ -41,12 +41,12 @@
   justify-content: center;
 }
 
-.card.with-border .card-image {
+.franklin-card.with-border .card-image {
   height: 155px;
   margin-bottom: 30px;
 }
 
-.card.with-border > a {
+.franklin-card.with-border > a {
   display: block;
   margin: 0 auto;
   padding: 24px 0;
@@ -54,11 +54,11 @@
   z-index: 2;
 }
 
-.card .card-image picture {
+.franklin-card .card-image picture {
   display: block;
 }
 
-.card .card-image img {
+.franklin-card .card-image img {
   height: auto;
   max-height: 100%;
   max-width: 100%;
@@ -66,65 +66,65 @@
   object-fit: cover;
 }
 
-.card .card-body {
+.franklin-card .card-body {
   text-align: center;
   line-height: 1.5;
   padding: 0;
   margin-bottom: 30px;
 }
 
-.card:not(.with-border) .card-body {
+.franklin-card:not(.with-border) .card-body {
   color: var(--text-color);
 }
 
-.card .card-body p {
+.franklin-card .card-body p {
   margin: 0;
   padding: 0;
 }
 
-.card .card-body p:first-child {
+.franklin-card .card-body p:first-child {
   font-size: 1.375rem;
 }
 
-.card .card-body p:nth-child(2) {
+.franklin-card .card-body p:nth-child(2) {
   font-size: 1rem;
   line-height: 1.19;
 }
 
-.card .card-body p:nth-child(3) {
+.franklin-card .card-body p:nth-child(3) {
   font-size: 1rem;
   letter-spacing: .2px;
   line-height: 1.5;
 }
 
-.card .card-body p strong {
+.franklin-card .card-body p strong {
   font-weight: 700;
   font-size: 1.375rem;
 }
 
-.cards.columns-3 .card {
+.cards.columns-3 .franklin-card {
   width: calc(33.3333% - 15px);
 }
 
-.cards.columns-4 .card {
+.cards.columns-4 .franklin-card {
   width: calc(25% - 15px);
 }
 
-.cards.columns-5 .card {
+.cards.columns-5 .franklin-card {
   width: calc(20% - 25px);
 }
 
 
 @media (max-width: 1023px) {
-  .cards.columns-4 .card {
+  .cards.columns-4 .franklin-card {
     width: calc(50% - 10px);
   }
 
-  .cards.columns-5 .card {
+  .cards.columns-5 .franklin-card {
     width: 50%;
   }
 
-  .cards.columns-3 .card {
+  .cards.columns-3 .franklin-card {
     width: calc(50% - 10px);
   }
 
@@ -134,26 +134,26 @@
 }
 
 @media (max-width: 767px) {
-  .cards.columns-5 .card {
+  .cards.columns-5 .franklin-card {
     width: 100%;
   }
 }
 
 @media (max-width: 599px) {
-  .cards.columns-3 .card {
+  .cards.columns-3 .franklin-card {
     width: 100%;
     margin-top: 30px;
   }
 
-  .cards.columns-4 .card {
+  .cards.columns-4 .franklin-card {
     width: 100%;
   }
 }
 
-.card.with-border .card-body p:first-child,
-.card.with-border .card-body p:nth-child(2),
-.card.with-border .card-body p:nth-child(3),
-.card.with-border .card-body p strong {
+.franklin-card.with-border .card-body p:first-child,
+.franklin-card.with-border .card-body p:nth-child(2),
+.franklin-card.with-border .card-body p:nth-child(3),
+.franklin-card.with-border .card-body p strong {
   font-size: 1rem;
   line-height: 1.5;
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -10,7 +10,7 @@ function decorateCuratedCards(block) {
   /* change to ul, li */
   const list = ul();
   [...block.children].forEach((row) => {
-    const listItem = li({ class: `card ${cardsWithBorder ? ' with-border' : ''}` });
+    const listItem = li({ class: `franklin-card ${cardsWithBorder ? ' with-border' : ''}` });
 
     const link = row.querySelector('a');
     let parent = listItem;
@@ -62,7 +62,7 @@ async function decorateAPICards(block) {
   block.append(
     ul(
       ...apiInfo.offers.map((offer) => (
-        li({ class: `card ${cardsWithBorder ? ' with-border' : ''}` },
+        li({ class: `franklin-card ${cardsWithBorder ? ' with-border' : ''}` },
           a({ href: apiCardLink(offer) },
             div({ class: 'card-image' },
               img({


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Partial for #54 . Use a different class name for our cards, to avoid CSS clash with the Walgreens externally loaded CSS and causing CLS. This will improve the LHS.

Follow up on #13 

Test URLs:
- Before: https://main--walgreens--hlxsites.hlx.live/topic/promotion/beautydeals
- After: https://fix-cards-cls--walgreens--hlxsites.hlx.live/topic/promotion/beautydeals

- Before: https://main--walgreens--hlxsites.hlx.live/topic/promotion/walgreens-online-deals
- After: https://fix-cards-cls--walgreens--hlxsites.hlx.live/topic/promotion/walgreens-online-deals

- Before: https://main--walgreens--hlxsites.hlx.live/topic/promotion/personal-care-deals
- After: https://fix-cards-cls--walgreens--hlxsites.hlx.live/topic/promotion/personal-care-deals

- Before: https://main--walgreens--hlxsites.hlx.live/topic/promotion/health-wellness-deals
- After: https://fix-cards-cls--walgreens--hlxsites.hlx.live/topic/promotion/health-wellness-deals

- Before: https://main--walgreens--hlxsites.hlx.live/store/catalog/shoplanding
- After: https://fix-cards-cls--walgreens--hlxsites.hlx.live/store/catalog/shoplanding
